### PR TITLE
Currency can be pulled from shop.currency

### DIFF
--- a/uv.liquid
+++ b/uv.liquid
@@ -14,6 +14,7 @@
     // http://docs.shopify.com/themes/liquid-variables/global
     var template = "{{ template }}";
     var pageTitle = "{{ page_title }}";
+    var shopCurrency = "{{ shop.currency }}";
 
     // http://docs.shopify.com/api/product
     var product = {{ product | json }};
@@ -87,6 +88,7 @@
         id: String(product.id),
 
         // path is not attached to the shopify product, pass back as the pathname
+        // Consider using: {{ product.url }}
         url: window.location.pathname,
 
 
@@ -99,7 +101,7 @@
         // TOOD: loop through the tags[] array and add them as key value pairs on a deeper level 
         // e.g. subsubcategory, subsubsubcategory
         subcategory: product.tags[0], 
-        currency: "GBP",
+        currency: shopCurrency,
         unit_price: product.price / 100,
         unit_sale_price: product.price_min / 100,
 
@@ -199,8 +201,7 @@
     uv.basket =  {
       id: basket.token,
 
-      // TODO
-      // currency: GBP,
+      currency: shopCurrency,
 
       subtotal: basket.total_price,
 
@@ -268,7 +269,3 @@
 }());
 </script>
 <!-- Qubit Universal Variable end -->
-
-<!-- Opentag container REPLACE XXXX-XXXX with your own id -->
-<script src='//d3c3cq33003psk.cloudfront.net/opentag-XXXX-XXXX.js' async defer></script>
-<!-- Opentag container end -->

--- a/uv.liquid
+++ b/uv.liquid
@@ -270,6 +270,6 @@
 </script>
 <!-- Qubit Universal Variable end -->
 
- -<!-- Opentag container REPLACE XXXX-XXXX with your own id -->
- -<script src='//d3c3cq33003psk.cloudfront.net/opentag-XXXX-XXXX.js' async defer></script>
- -<!-- Opentag container end -->
+<!-- Opentag container REPLACE XXXX-XXXX with your own id -->
+<script src='//d3c3cq33003psk.cloudfront.net/opentag-XXXX-XXXX.js' async defer></script>
+<!-- Opentag container end -->

--- a/uv.liquid
+++ b/uv.liquid
@@ -269,3 +269,7 @@
 }());
 </script>
 <!-- Qubit Universal Variable end -->
+
+ -<!-- Opentag container REPLACE XXXX-XXXX with your own id -->
+ -<script src='//d3c3cq33003psk.cloudfront.net/opentag-XXXX-XXXX.js' async defer></script>
+ -<!-- Opentag container end -->


### PR DESCRIPTION
Added currency (from shop.currency) to Product and Basket objects.

A few additional comments:
1. IMO OpenTag should NOT be included as part of the script, since UV can be used independently of OpenTag. Plus, some "customers" may already have OpenTag installed on their sites which may lead to duplicate tags if not careful.
2. The "Docs" say to use {% include 'universal-variable' %} but I believe this should be {% include 'uv' %} because the file is named "uv.liquid"
3. The TODO to "Loop through product tags" to create sub-sub-categories is a bad idea because of the various ways that tags are used in Shopify to control logic.
