### PR TITLE
Change order id to reflect the Shopify order id

### DIFF
--- a/uv-transaction.liquid
+++ b/uv-transaction.liquid
@@ -31,7 +31,7 @@
    */
 
     uv.transaction = {
-      order_id: "{{ order_number }}",
+      order_id: "{{ id }}",
       currency: "{{ shop.currency }}",
       subtotal: {{ subtotal_price | money_without_currency }},
       subtotal_include_tax: true,


### PR DESCRIPTION
The `order_number` field being used is not technically the Shopify order id. The `id` field is technically the correct one to use, as it corresponds to the `id` field in the Shopify order docs: http://docs.shopify.com/api/order
